### PR TITLE
Fix/remove building unselection navigating

### DIFF
--- a/app/backend/src/services/mapService.ts
+++ b/app/backend/src/services/mapService.ts
@@ -8,8 +8,6 @@ export const getDirections = async (
 ) => {
   // UNCOMMENT THIS TO TEST FOR FREE:
 
-  /*
-  
   console.log("MOCK MODE: Returning fake route");
   return {
     status: "OK",
@@ -41,7 +39,7 @@ export const getDirections = async (
     },
   };
 
-  */
+
 
   // Use the key from config
   const apiKey = config.googleMapsApiKey;

--- a/app/frontend/src/features/map/hooks/useMapLogic.ts
+++ b/app/frontend/src/features/map/hooks/useMapLogic.ts
@@ -92,6 +92,7 @@ export const useMapLogic = () => {
   };
 
   const handleBuildingPress = (building: Building) => {
+    if(isNavigating) return; // Prevent changing selection while navigating
     setSelectedBuilding(building);
     resetRoutingState();
   };

--- a/app/frontend/src/features/map/screens/MapScreen.tsx
+++ b/app/frontend/src/features/map/screens/MapScreen.tsx
@@ -70,7 +70,8 @@ const MapScreen = () => {
             currentBuildingId={currentBuilding?.id}
             selectedBuildingId={selectedBuilding?.id}
             onBuildingPress={handleBuildingPress}
-            onMapPress={() => setSelectedBuilding(null)}
+            // When navigating, we want to disable deselecting buildings by tapping the map, to prevent accidental taps from disrupting navigation. --- IGNORE ---
+            onMapPress={isNavigating ? () => {} : () => setSelectedBuilding(null)}
             routeCoords={routeCoords}
             transportMode={transportMode}
           />


### PR DESCRIPTION
Isolate the navigation state. With this fix, the user cannot exit the isolation state by selecting another building on the map, or pressing on the map to unselect