### PR TITLE
147 fix step by step instructions from sprint 2

### DIFF
--- a/app/backend/src/services/mapService.ts
+++ b/app/backend/src/services/mapService.ts
@@ -56,7 +56,7 @@ export const getDirections = async (
     const steps = leg.steps.map((step: any, index: number) => ({
       //processing step by step directions
       stepNumber: index + 1,
-      instruction: step.html_instructions.replace(/<[^>]*>/g, ""), //removes html tags
+      instruction: step.html_instructions.replace(/<[^>]{0,1000}>/g, ""), //removes html tags
       distance: step.distance.text,
       duration: step.duration.text,
       maneuver: step.maneuver || "straight",


### PR DESCRIPTION
Limited the regex quantifier in HTML stripping to address codecov security issue.
Before (in mapService.ts line 59):
`/<[^>]*>/g`

Now:
`/<[^>]{0,1000}>/g`
