### PR TITLE
[FIX]: Resolve "runs between campuses only" shuttle error

### DIFF
--- a/app/frontend/src/features/map/hooks/useMapLogic.ts
+++ b/app/frontend/src/features/map/hooks/useMapLogic.ts
@@ -239,8 +239,7 @@ export const useMapLogic = () => {
       return;
     }
 
-    const destinationCampus = selectedBuilding?.campus || null;
-
+    const destinationCampus = destination.campus || selectedBuilding?.campus || null;
     const shuttleInfo = getNextShuttleInfo(origin.campus, destinationCampus);
 
     setNextShuttleTitle(shuttleInfo.title);


### PR DESCRIPTION
## 📝 Description
This PR fixes a bug where the shuttle navigation mode incorrectly evaluated the origin and destination as being on the same campus when a building was selected as the starting point.
`useMapLogic.ts`: Updated the shuttle `useEffect` to prioritize `destination.campus` over `selectedBuilding?.campus.` This ensures the app correctly identifies when the user wants to route to a different campus, rather than falling back to the currently selected building.

## 🚀 PR Type
What kind of change does this PR introduce? (Check all that apply)
- [x] 🐛 Bugfix
- [ ] ✨ Feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/UX Update
- [ ] 🧪 Testing

## 🔗 Traceability
* **Resolves Issue:** https://github.com/yassineAbdellatif/Git-happens/issues/187

---

## 📱 Testing Performed
iOS Simulator (iPhone 17)

## 📸 Screenshots / Video (If UI changed)
| Before | After |
| ------ | ----- |
| <img src="https://github.com/user-attachments/assets/a8872766-95ee-421f-b329-fcf7324ceecd" width="400"/> | <img src="https://github.com/user-attachments/assets/4544503c-09c9-4a93-bf30-0e441bec5ce1" width="400"/> |
