### PR TITLE
Added indoor POI details card (UI & logic)

### DIFF
--- a/app/frontend/src/features/map/components/FloorPlanDisplay.tsx
+++ b/app/frontend/src/features/map/components/FloorPlanDisplay.tsx
@@ -8,6 +8,8 @@ import {
   View,
   StyleSheet,
   Dimensions,
+  Modal, 
+  Pressable,
 } from "react-native";
 import {
   FloorPlanRegistryEntry,
@@ -51,6 +53,27 @@ const POI_ASSETS: Partial<
   ),
 };
 
+const POI_DETAILS: Partial<
+  Record<LocalizedNodeType, { title: string; description?: string }>
+> = {
+  washroom: {
+    title: "Washroom",
+    description: "Men's / Women's washroom",
+  },
+  elevator: {
+    title: "Elevator",
+    description: "Inter-floor access",
+  },
+  stair_landing: {
+    title: "Stairs",
+    description: "Stair access between floors",
+  },
+  water_fountain: {
+    title: "Water Fountain",
+    description: "Drinking water available",
+  },
+};
+
 const PNG_ASSET_MAP: Record<string, ImageSourcePropType> = {
   H_1: require("../../../../assets/updated_floor_plans/h1.png"),
   H_2: require("../../../../assets/updated_floor_plans/h2.png"),
@@ -77,6 +100,8 @@ const FloorPlanDisplay = ({
   // Map the building ID and floor number to the correct PNG
   const mapImageKey = `${floorPlanEntry.buildingId}_${floorPlanEntry.floorNumber}`;
   const MapImageSource = PNG_ASSET_MAP[mapImageKey];
+
+  const [selectedPoi, setSelectedPoi] = React.useState<LocalizedNode | null>(null);
 
   // To use image as SVG viewBox so node coordinates align correctly
   const naturalSize = MapImageSource
@@ -159,7 +184,11 @@ const FloorPlanDisplay = ({
                         height={POI_ICON_SIZE}
                         href={{ uri: asset.uri }}
                         preserveAspectRatio="xMidYMid meet"
-                        onPress={() => onPoiPress?.(node)}
+                        onPress={() => {
+                          setSelectedPoi(node);
+                          onPoiPress?.(node);
+                          console.log(`POI pressed: ${node.label}`);
+                        }}
                       />
                     );
                   })}
@@ -168,19 +197,23 @@ const FloorPlanDisplay = ({
                   The icons are put into the PNG directly so we can't interact with them directly —
                   therefore, these invisible Rects sit at the same coordinates and forward taps to onPoiPress for 4.4.2 . */}
               {floorPlanEntry.poiIconsEmbedded &&
-                floorPlanEntry.localizedNodes
-                  .filter((node) => node.nodeType in POI_ASSETS)
-                  .map((node) => (
-                    <Rect
-                      key={node.id}
-                      x={node.x - POI_ICON_SIZE / 2}
-                      y={node.y - POI_ICON_SIZE / 2}
-                      width={POI_ICON_SIZE}
-                      height={POI_ICON_SIZE}
-                      fill="transparent"
-                      onPress={() => onPoiPress?.(node)}
-                    />
-                  ))}
+              floorPlanEntry.localizedNodes
+                .filter((node) => node.nodeType in POI_ASSETS)
+                .map((node) => (
+                  <Rect
+                    key={node.id}
+                    x={node.x - POI_ICON_SIZE / 2}
+                    y={node.y - POI_ICON_SIZE / 2}
+                    width={POI_ICON_SIZE}
+                    height={POI_ICON_SIZE}
+                    fill="rgba(252, 116, 116, 0.58)"
+                    onPress={() => {
+                      console.log("POI pressed", node.id);
+                      setSelectedPoi(node);
+                      onPoiPress?.(node);
+                    }}
+                  />
+                ))}
 
               {/* Navigation path */}
               {path.length > 1 && (
@@ -215,6 +248,39 @@ const FloorPlanDisplay = ({
           )}
         </Animated.View>
       </View>
+      <Modal
+        visible={!!selectedPoi}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSelectedPoi(null)}
+      >
+        <Pressable
+          style={styles.modalOverlay}
+          onPress={() => setSelectedPoi(null)}
+        >
+          <View style={styles.tooltip}>
+            <Text style={styles.tooltipTitle}>
+              {selectedPoi
+                ? POI_DETAILS[selectedPoi.nodeType]?.title ||
+                  selectedPoi.label
+                : ""}
+            </Text>
+
+            {selectedPoi &&
+              POI_DETAILS[selectedPoi.nodeType]?.description && (
+                <Text style={styles.tooltipDescription}>
+                  {POI_DETAILS[selectedPoi.nodeType]?.description}
+                </Text>
+              )}
+
+            {selectedPoi?.label && (
+              <Text style={styles.tooltipMeta}>
+                {selectedPoi.label}
+              </Text>
+            )}
+          </View>
+        </Pressable>
+      </Modal>
     </View>
   );
 };
@@ -270,6 +336,41 @@ const styles = StyleSheet.create({
     fontSize: 16,
     textAlign: "center",
   },
+  modalOverlay: {
+  flex: 1,
+  backgroundColor: "rgba(0,0,0,0.2)",
+  justifyContent: "center",
+  alignItems: "center",
+},
+
+tooltip: {
+  backgroundColor: "white",
+  padding: 16,
+  borderRadius: 10,
+  minWidth: 180,
+  shadowColor: "#000",
+  shadowOffset: { width: 0, height: 2 },
+  shadowOpacity: 0.2,
+  shadowRadius: 6,
+  elevation: 5,
+},
+
+tooltipTitle: {
+  fontSize: 16,
+  fontWeight: "700",
+  marginBottom: 4,
+},
+
+tooltipDescription: {
+  fontSize: 13,
+  color: "#555",
+},
+
+tooltipMeta: {
+  fontSize: 12,
+  color: "#999",
+  marginTop: 6,
+},
 });
 
 export default FloorPlanDisplay;

--- a/app/frontend/src/features/map/hooks/useIndoorFloorPlanState.ts
+++ b/app/frontend/src/features/map/hooks/useIndoorFloorPlanState.ts
@@ -48,8 +48,11 @@ export const useIndoorFloorPlanInteraction = (
   const panResponder = useMemo(
     () =>
       PanResponder.create({
-        onMoveShouldSetPanResponder: () => true,
-        onStartShouldSetPanResponderCapture: () => true,
+        onStartShouldSetPanResponder: () => false,
+        onStartShouldSetPanResponderCapture: () => false,
+        onMoveShouldSetPanResponder: (_, gestureState) => {
+          return Math.abs(gestureState.dx) > 5 || Math.abs(gestureState.dy) > 5;
+        },
         onMoveShouldSetPanResponderCapture: () => true,
         onPanResponderGrant: () => {
           onInteractionChange?.(true);


### PR DESCRIPTION
## 📝 Description
Added the UI and logic handler of `onPoiPress `to display a details pop-up of the clicked POI. 
Added color to the exact node locations to click on POI, since png coordinates mismatch.

Although the original plan was to Pass `onPoiPress `from `IndoorMapScreen`, it required more setup but did not end up working because of the floorplans with embedded png icons. Instead, I:
- Moved POI interaction handling fully into `FloorPlanDisplay`, adding internal state and a modal, instead of relying solely on the parent `onPoiPress `handler. 
- Standardized behavior so both SVG icons and embedded-icon <Rect> hit targets trigger the same logic and UI. 
- Simplified the implementation by removing the extra overlay touch layer and handling all POI presses directly within the component.

## 🚀 PR Type
What kind of change does this PR introduce? (Check all that apply)
- [ ] 🐛 Bugfix
- [X] ✨ Feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/UX Update
- [ ] 🧪 Testing

## 🔗 Traceability
*Resolves Issue `#77`

---

## 📱 Testing Performed
[Describe how you tested these changes. Since this is a mobile project, specify the environments used.]
- [ ] iOS Simulator (iPhone __)
- [ ] Android Emulator (Pixel __)
- [X] Physical Device

## 📸 Screenshots
<img width="247" height="530" alt="image" src="https://github.com/user-attachments/assets/882b706f-49df-45f4-851c-441170a32f5d" />
<img width="241" height="530" alt="image" src="https://github.com/user-attachments/assets/92b60fbc-db05-4f84-96d2-12caf9c1d7c2" />


## ✔️ Checklist
- [X] My code follows the project's style guidelines.
- [X] I have updated the tests to cover my changes (if applicable).
- [X] I have added refactoring details and links for the sprint report (if applicable).