### PR TITLE
feature 5.2 add directions to POI with routing

### DIFF
--- a/app/frontend/src/features/map/components/POIPanel.tsx
+++ b/app/frontend/src/features/map/components/POIPanel.tsx
@@ -24,6 +24,7 @@ interface POIPanelProps {
   onClose: () => void;
   userLocation: { latitude: number; longitude: number } | null;
   onSelectPOI: (poi: POIResult) => void;
+  onGetDirections: (poi: POIResult) => void;
 }
 
 const StarRating = ({ rating }: { rating: number | null }) => {
@@ -55,6 +56,7 @@ export const POIPanel: React.FC<POIPanelProps> = ({
   onClose,
   userLocation,
   onSelectPOI,
+  onGetDirections,
 }) => {
   const hasResults = results.length > 0;
 
@@ -167,6 +169,15 @@ export const POIPanel: React.FC<POIPanelProps> = ({
                     </View>
                   )}
                 </View>
+                {/* TSK-5.2.2: Get Directions quick action */}
+                <TouchableOpacity
+                  style={styles.directionsBtn}
+                  onPress={() => onGetDirections(poi)}
+                  activeOpacity={0.75}
+                >
+                  <MaterialIcons name="directions" size={14} color="#fff" />
+                  <Text style={styles.directionsBtnText}>Get Directions</Text>
+                </TouchableOpacity>
               </View>
               {poi.distanceM !== null && (
                 <Text style={styles.distanceText}>
@@ -240,6 +251,8 @@ const styles = StyleSheet.create({
   openBadge: { paddingHorizontal: 5, paddingVertical: 1, borderRadius: 4 },
   openBadgeText: { fontSize: 10, color: "#fff", fontWeight: "600" },
   distanceText: { fontSize: 12, color: "#555", fontWeight: "600" },
+  directionsBtn: { flexDirection: "row", alignItems: "center", gap: 4, marginTop: 6, alignSelf: "flex-start", backgroundColor: "#912338", paddingHorizontal: 10, paddingVertical: 4, borderRadius: 12 },
+  directionsBtnText: { fontSize: 11, color: "#fff", fontWeight: "700" },
   emptyState: { alignItems: "center", paddingVertical: 30, gap: 10 },
   emptyText: { fontSize: 13, color: "#aaa", textAlign: "center", paddingHorizontal: 30 },
 });

--- a/app/frontend/src/features/map/screens/MapScreen.tsx
+++ b/app/frontend/src/features/map/screens/MapScreen.tsx
@@ -355,11 +355,33 @@ const MapScreen = () => {
                   );
                 }
               }}
+              onGetDirections={(p) => {
+                // TSK-5.2.1: Pass selected POI coordinates to the directions service
+                setDestination({
+                  type: "BUILDING",
+                  coords: { latitude: p.location.latitude, longitude: p.location.longitude },
+                  label: p.name,
+                  campus: null,
+                });
+                if (userLocation) {
+                  setOrigin({
+                    type: "CURRENT",
+                    coords: { latitude: userLocation.latitude, longitude: userLocation.longitude },
+                    label: "My Location",
+                    campus: null,
+                  });
+                } else {
+                  setOrigin({ type: null, coords: null, label: "Choose starting point", campus: null });
+                }
+                poi.setIsOpen(false);
+                poi.clearResults();
+                setIsRouting(true);
+              }}
             />
           )}
 
           {/* BOTTOM SHEET */}
-          {selectedBuilding && !isNavigating && (
+          {(selectedBuilding || isRouting) && !isNavigating && (
             <View
               style={[
                 styles.bottomSheetMock,
@@ -373,7 +395,7 @@ const MapScreen = () => {
                 showsVerticalScrollIndicator={false}
                 scrollEnabled={!isIndoorInteracting}
               >
-                {!isRouting ? (
+                {!isRouting && selectedBuilding ? (
                   <>
                     <Text style={styles.sheetTitle}>
                       {selectedBuilding.fullName}


### PR DESCRIPTION

## 📝 Description
This PR implements TSK-5.2: adding direction support from the nearby POI panel. When a user finds a nearby place of interest (restaurant, café, pharmacy, etc.) using the POI search panel, they can now tap a **"Get Directions"** button directly on the result card. This automatically sets their current location as the origin and the selected POI as the destination, closes the POI panel, and opens the routing flow — landing directly on the travel mode picker ready to start navigation.

## 🚀 PR Type

- [ ] 🐛 Bugfix
- [x] ✨ Feature
- [ ] ♻️ Refactoring
- [x] 💄 UI/UX Update
- [ ] 🧪 Testing

## 🔗 Traceability
* **Resolves Issue(s):** `fixes #TSK-5.2`, `fixes #TSK-5.2.1`, `fixes #TSK-5.2.2`

---

## ♻️ Refactoring Details (If Applicable)
N/A

---

## 📱 Testing Performed

- [ ] iOS Simulator (iPhone __)
- [x] Android Emulator (Pixel __)
- [ ] Physical Device

## 📸 Screenshots / Video (If UI changed)
<img width="374" height="862" alt="image" src="https://github.com/user-attachments/assets/a2188023-c028-4647-8019-51fe5118fda0" />

<img width="373" height="868" alt="image" src="https://github.com/user-attachments/assets/a818f8ef-92e3-486a-bd10-7e1e92c32e6b" />


## ✔️ Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have updated the tests to cover my changes (if applicable).
- [ ] I have added refactoring details and links for the sprint report (if applicable).
